### PR TITLE
fix findomain installation

### DIFF
--- a/frogy.sh
+++ b/frogy.sh
@@ -146,7 +146,7 @@ fi
 
 #################### FINDOMAIN ENUMERATION ######################
 
-findomain-linux -t $domain_name -q >> output/$cdir/findomain.txtls
+findomain -t $domain_name -q >> output/$cdir/findomain.txtls
 cat output/$cdir/findomain.txtls|anew|grep -v " "|grep -v "@" | grep "\." >> all.txtls
 echo -e "\e[36mFindomain count: \e[32m$(cat output/$cdir/findomain.txtls | tr '[:upper:]' '[:lower:]'| anew |grep -v " "|grep -v "@" | grep "\."| wc -l)\e[0m"
 

--- a/install.sh
+++ b/install.sh
@@ -13,9 +13,9 @@ go install -v github.com/tomnomnom/waybackurls@latest
 go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest
 apt install -y amass
 go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
-wget https://github.com/findomain/findomain/releases/latest/download/findomain-linux
-chmod +x findomain-linux
-mv findomain-linux /usr/bin/
+wget https://github.com/findomain/findomain/releases/latest/download/findomain-linux.zip && unzip findomain-linux.zip
+chmod +x findomain
+mv findomain /usr/bin/
 go install -v github.com/cgboal/sonarsearch/cmd/crobat@latest
 cd /root/go/bin
 cp anew httpx crobat subfinder /usr/bin/


### PR DESCRIPTION
The link to download Findomain tool needs a '.zip' at the end of it and then unzip it so we get the tool's file
